### PR TITLE
Added error management

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ And now, you can use the converter, by passing options to render method.
   translations : {  // Object, dynamically overwrite all loaded translations for this rendering
     fr : {'one':'un' },
     es : {'one':'uno'}
-  }
+  },
+  throwErrorOnUndefined : false // Boolean, if one of the data defined in the xml doesn't exist, throw an error
 }
 ```
 
@@ -303,6 +304,7 @@ Set general carbone parameters.
     },
     factories    : 1, // Number of LibreOffice worker 
     startFactory : false // If true, start LibreOffice worker immediately
+    throwErrorOnUndefined : false // Boolean, if one of the data defined in the xml doesn't exist, throw an error
   }
 ```
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -685,10 +685,10 @@ function genErrorGest (description, option) {
 		        _tab = false;
 		      }
 		    }
-		    res += 'if (data.'+_name+' == undefined)\n'//&& options.throwErrorOnUndefined == true)\n'
+		    res += 'if (data.'+_name+' == undefined)&& options.throwErrorOnUndefined == true)\n'
         res += '  throw new Error("Error: '+_name+' is undefined")\n'
-        // res += 'else if (data.'+_name+' == undefined && options.throwErrorOnUndefined == false)\n'
-        // res += '  debug("Warning: '+_name+' is undefined")\n'
+        res += 'else if (data.'+_name+' == undefined && options.throwErrorOnUndefined == false)\n'
+        res += '  debug("Warning: '+_name+' is undefined")\n'
       }
     }
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -41,7 +41,7 @@ var builder = {
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
 			        //console.log(util.inspect(_descriptor, false, null))
-              var _builder = builder.getBuilderFunction(_descriptor, options.formatters);
+              var _builder = builder.getBuilderFunction(_descriptor, options.formatters, options);
               var _obj = {
                 d : data,
                 c : options.complement
@@ -302,7 +302,7 @@ var builder = {
    * @param {object} descriptor : data descriptor computed by the analyzer
    * @return {function} f
    */
-  getBuilderFunction : function (descriptor, existingFormatters) {
+  getBuilderFunction : function (descriptor, existingFormatters, options) {
     var that = this;
     // declare an object which will contain all the code (by section) of the generated function
     var _code = {
@@ -326,7 +326,7 @@ var builder = {
     _code.add('init', 'var _formatterOptions = { lang : options.lang, stopPropagation : false, enum : options.enum };\n');
     _code.add('init', 'var formatters = options.formatters;\n'); // used by getFormatterString
 
-    var _errorGest = genErrorGest(descriptor);
+    var _errorGest = genErrorGest(descriptor, options);
     _code.add('init', _errorGest);
     var _atLeastOneSpecialIterator = false;
     // _str += "var _nestedArrayParams = [];\n";

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -39,6 +39,8 @@ var builder = {
               var _descriptor = extracter.splitXml(xmlWithoutMarkers, _dynamicDescriptor);
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
+	      const util = require('util')
+	      console.log(util.inspect(_descriptor, {showHidden: false, depth: null}))
               var _builder = builder.getBuilderFunction(_descriptor, options.formatters);
               var _obj = {
                 d : data,
@@ -324,6 +326,8 @@ var builder = {
     _code.add('init', 'var _formatterOptions = { lang : options.lang, stopPropagation : false, enum : options.enum };\n');
     _code.add('init', 'var formatters = options.formatters;\n'); // used by getFormatterString
 
+    var _errorGest = genErrorGest(descriptor);
+    _code.add('init', _errorGest);
     var _atLeastOneSpecialIterator = false;
     // _str += "var _nestedArrayParams = [];\n";
     var _lastArrayEnd = 0;
@@ -636,4 +640,26 @@ function removeFrom (arr, value) {
   return arr;
 }
 
-
+  /**
+   * Generate an error management code using a description for the data object.
+   *
+   * @param {object} descriptor : data descriptor computed by the analyzer
+   * @return {string} s
+   */
+function genErrorGest (description) {
+  var res = '';
+  for (var i = 0 ; description.hierarchy[i] ; i++) {
+    if (description.dynamicData[description.hierarchy[i]].xmlParts.length != 0) {
+      for (var j = 0 ; description.dynamicData[description.hierarchy[i]].xmlParts[j] ; j++) {
+        var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr;
+        var _parent = description.dynamicData[description.hierarchy[i]].xmlParts[j].obj;
+        var _parentName = description.dynamicData[_parent].name;
+        if (_parentName == 'd') {
+          res += 'if (data.'+_parentName+'.'+_name+' == undefined)\n'
+          res += '  throw new Error("Error: '+_parentName+'.'+_name+' doesn\'t exist")\n'
+        }
+      }
+    }
+  }
+  return (res);
+}

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -39,8 +39,6 @@ var builder = {
               var _descriptor = extracter.splitXml(xmlWithoutMarkers, _dynamicDescriptor);
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
-	      const util = require('util')
-	      console.log(util.inspect(_descriptor, {showHidden: false, depth: null}))
               var _builder = builder.getBuilderFunction(_descriptor, options.formatters);
               var _obj = {
                 d : data,
@@ -651,13 +649,24 @@ function genErrorGest (description) {
   for (var i = 0 ; description.hierarchy[i] ; i++) {
     if (description.dynamicData[description.hierarchy[i]].xmlParts.length != 0) {
       for (var j = 0 ; description.dynamicData[description.hierarchy[i]].xmlParts[j] ; j++) {
-        var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr;
-        var _parent = description.dynamicData[description.hierarchy[i]].xmlParts[j].obj;
-        var _parentName = description.dynamicData[_parent].name;
-        if (_parentName == 'd') {
-          res += 'if (data.'+_parentName+'.'+_name+' == undefined)\n'
-          res += '  throw new Error("Error: '+_parentName+'.'+_name+' doesn\'t exist")\n'
+        var _parentsArray = []
+        for (var k = 0 ; description.dynamicData[description.hierarchy[i]].parents[k] ; k++) {
+          var _tmpParent = description.dynamicData[description.hierarchy[i]].parents[k];
+          _parentsArray.push(description.dynamicData[_tmpParent].name);
         }
+        var _parent = description.dynamicData[description.hierarchy[i]].xmlParts[j].obj;
+        var _parent = description.dynamicData[_parent].name;
+        var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr
+        _parentsArray.push(_parent);
+        _parentsArray.push(_name);
+        _name = _parentsArray[1] + '.'
+        for (k = 2 ; _parentsArray[k] ; k++) {
+          _name += _parentsArray[k];
+          if (_parentsArray[k + 1])
+            _name += '.';
+        }
+        res += 'if (data.'+_name+' == undefined)\n'
+        res += '  throw new Error("Error: '+_name+' doesn\'t exist")\n'
       }
     }
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -685,7 +685,7 @@ function genErrorGest (description, option) {
 		        _tab = false;
 		      }
 		    }
-		    res += 'if (data.'+_name+' == undefined)&& options.throwErrorOnUndefined == true)\n'
+		    res += 'if (data.'+_name+' == undefined && options.throwErrorOnUndefined == true)\n'
         res += '  throw new Error("Error: '+_name+' is undefined")\n'
         res += 'else if (data.'+_name+' == undefined && options.throwErrorOnUndefined == false)\n'
         res += '  debug("Warning: '+_name+' is undefined")\n'

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,6 +1,7 @@
 var extracter = require('./extracter');
 var parser = require('./parser');
 var helper = require('./helper');
+// var util = require('util')
 
 var builder = {
 
@@ -39,7 +40,8 @@ var builder = {
               var _descriptor = extracter.splitXml(xmlWithoutMarkers, _dynamicDescriptor);
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
-              var _builder = builder.getBuilderFunction(_descriptor, options.formatters, options);
+              // console.log(util.inspect(_descriptor, false, null));
+              var _builder = builder.getBuilderFunction(_descriptor, options.formatters);
               var _obj = {
                 d : data,
                 c : options.complement
@@ -300,7 +302,7 @@ var builder = {
    * @param {object} descriptor : data descriptor computed by the analyzer
    * @return {function} f
    */
-  getBuilderFunction : function (descriptor, existingFormatters, options) {
+  getBuilderFunction : function (descriptor, existingFormatters) {
     var that = this;
     // declare an object which will contain all the code (by section) of the generated function
     var _code = {
@@ -324,7 +326,7 @@ var builder = {
     _code.add('init', 'var _formatterOptions = { lang : options.lang, stopPropagation : false, enum : options.enum };\n');
     _code.add('init', 'var formatters = options.formatters;\n'); // used by getFormatterString
 
-    var _errorGest = genErrorGest(descriptor, options);
+    var _errorGest = genErrorGest(descriptor);
     _code.add('init', _errorGest);
     var _atLeastOneSpecialIterator = false;
     // _str += "var _nestedArrayParams = [];\n";
@@ -649,11 +651,7 @@ function genErrorGest (description, option) {
     if (description.dynamicData[description.hierarchy[i]].xmlParts.length != 0) {
       for (var j = 0 ; description.dynamicData[description.hierarchy[i]].xmlParts[j] ; j++) {
         var _parentsArray = []
-		    var _type = description.dynamicData[description.hierarchy[i]].type
-		    if (_type == 'array')
-		      var _which = description.dynamicData[description.hierarchy[i]].name;
         for (var k = 0 ; description.dynamicData[description.hierarchy[i]].parents[k] ; k++) {
-          var _parentsArray = [];
           var _tmpParent = 
           { 
             name : description.dynamicData[description.hierarchy[i]].parents[k],
@@ -669,20 +667,28 @@ function genErrorGest (description, option) {
         var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr
         _parentsArray.push({name : _parent, type : _parentType});
         _parentsArray.push({name : _name, type : "string"});
-        _name = '';
-        for (k = 0 ; _parentsArray[k] ; k++) {
-          _name += _parentsArray[k].name;
-          if (_parentsArray[k].type == 'array')
-            _name += '[0]';
-          if (_parentsArray[k + 1])
-            _name += '.';
+        var _path = ''
+        for (var l = 1 ; _parentsArray[l] ; l++) {
+          res += 'if (data.'+_path+_parentsArray[l].name+' === undefined && options.throwErrorOnUndefined == true)\n'
+          res += '  throw new Error("Error: '+_path+_parentsArray[l].name+' is undefined")\n'
+          if (_parentsArray[l].type == 'array') {
+            res += 'if (Array.isArray(data.'+_path+_parentsArray[l].name+') === false)\n';
+            res += '  throw new Error("Error: '+_path+_parentsArray[l].name+' is not array")\n';
+          }
+          _path += _parentsArray[l].name
+          if (_parentsArray[l].type === 'array')
+            _path += '[0]'
+          if (_parentsArray[l + 1])
+            _path += '.'
         }
-		    res += 'if (data.'+_name+' == undefined && options.throwErrorOnUndefined == true)\n'
-        res += '  throw new Error("Error: '+_name+' is undefined")\n'
-        res += 'else if (data.'+_name+' == undefined && options.throwErrorOnUndefined == false)\n'
-        res += '  debug("Warning: '+_name+' is undefined")\n'
       }
     }
   }
+  res = res.split('\n');
+  for (var m = 0 ; res[m]; m++) {
+    if (RegExp("Error:").test(res[m]) == true)
+      res[m] = res[m].replace(/\[0\]/, "[]");
+  }
+  res = res.join('\n');
   return (res);
 }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,7 +1,6 @@
 var extracter = require('./extracter');
 var parser = require('./parser');
 var helper = require('./helper');
-//var util = require('util');
 
 var builder = {
 
@@ -40,7 +39,6 @@ var builder = {
               var _descriptor = extracter.splitXml(xmlWithoutMarkers, _dynamicDescriptor);
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
-			        //console.log(util.inspect(_descriptor, false, null))
               var _builder = builder.getBuilderFunction(_descriptor, options.formatters, options);
               var _obj = {
                 d : data,
@@ -655,36 +653,30 @@ function genErrorGest (description, option) {
 		    if (_type == 'array')
 		      var _which = description.dynamicData[description.hierarchy[i]].name;
         for (var k = 0 ; description.dynamicData[description.hierarchy[i]].parents[k] ; k++) {
-          var _tmpParent = description.dynamicData[description.hierarchy[i]].parents[k];
-          _parentsArray.push(description.dynamicData[_tmpParent].name);
+          var _parentsArray = [];
+          var _tmpParent = 
+          { 
+            name : description.dynamicData[description.hierarchy[i]].parents[k],
+            type : description.dynamicData[description.hierarchy[i]].parents[k]
+          }
+          _tmpParent.name = description.dynamicData[_tmpParent.name].name
+          _tmpParent.type = description.dynamicData[_tmpParent.type].type
+          _parentsArray.push(_tmpParent);
         }
         var _parent = description.dynamicData[description.hierarchy[i]].xmlParts[j].obj;
+        var _parentType = description.dynamicData[_parent].type;
         var _parent = description.dynamicData[_parent].name;
         var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr
-        _parentsArray.push(_parent);
-        _parentsArray.push(_name);
-		    if (_type == 'object') {
-          _name = _parentsArray[1] + '.'
-          for (k = 2 ; _parentsArray[k] ; k++) {
-            _name += _parentsArray[k];
-            if (_parentsArray[k + 1])
+        _parentsArray.push({name : _parent, type : _parentType});
+        _parentsArray.push({name : _name, type : "string"});
+        _name = '';
+        for (k = 0 ; _parentsArray[k] ; k++) {
+          _name += _parentsArray[k].name;
+          if (_parentsArray[k].type == 'array')
+            _name += '[0]';
+          if (_parentsArray[k + 1])
             _name += '.';
-          }
-		    }
-		    else if (_type == 'array') {
-		      _name = '';
-		      var _tab = false;
-		      for (k = 1 ; _parentsArray[k] ; k++) {
-			      if (_parentsArray[k] == _which)
-			        _tab = true;
-		        _name += _parentsArray[k];
-			      if (_tab == true)
-		          _name += '[0]'
-		        if (_parentsArray[k + 1])
-			        _name += '.';
-		        _tab = false;
-		      }
-		    }
+        }
 		    res += 'if (data.'+_name+' == undefined && options.throwErrorOnUndefined == true)\n'
         res += '  throw new Error("Error: '+_name+' is undefined")\n'
         res += 'else if (data.'+_name+' == undefined && options.throwErrorOnUndefined == false)\n'

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,6 +1,7 @@
 var extracter = require('./extracter');
 var parser = require('./parser');
 var helper = require('./helper');
+//var util = require('util');
 
 var builder = {
 
@@ -39,6 +40,7 @@ var builder = {
               var _descriptor = extracter.splitXml(xmlWithoutMarkers, _dynamicDescriptor);
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
+			        //console.log(util.inspect(_descriptor, false, null))
               var _builder = builder.getBuilderFunction(_descriptor, options.formatters);
               var _obj = {
                 d : data,
@@ -577,7 +579,6 @@ var builder = {
     }
     return _fn;
   }
-
 };
 
 /** ***************************************************************************************************************/
@@ -644,12 +645,15 @@ function removeFrom (arr, value) {
    * @param {object} descriptor : data descriptor computed by the analyzer
    * @return {string} s
    */
-function genErrorGest (description) {
+function genErrorGest (description, option) {
   var res = '';
   for (var i = 0 ; description.hierarchy[i] ; i++) {
     if (description.dynamicData[description.hierarchy[i]].xmlParts.length != 0) {
       for (var j = 0 ; description.dynamicData[description.hierarchy[i]].xmlParts[j] ; j++) {
         var _parentsArray = []
+		    var _type = description.dynamicData[description.hierarchy[i]].type
+		    if (_type == 'array')
+		      var _which = description.dynamicData[description.hierarchy[i]].name;
         for (var k = 0 ; description.dynamicData[description.hierarchy[i]].parents[k] ; k++) {
           var _tmpParent = description.dynamicData[description.hierarchy[i]].parents[k];
           _parentsArray.push(description.dynamicData[_tmpParent].name);
@@ -659,14 +663,32 @@ function genErrorGest (description) {
         var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr
         _parentsArray.push(_parent);
         _parentsArray.push(_name);
-        _name = _parentsArray[1] + '.'
-        for (k = 2 ; _parentsArray[k] ; k++) {
-          _name += _parentsArray[k];
-          if (_parentsArray[k + 1])
+		    if (_type == 'object') {
+          _name = _parentsArray[1] + '.'
+          for (k = 2 ; _parentsArray[k] ; k++) {
+            _name += _parentsArray[k];
+            if (_parentsArray[k + 1])
             _name += '.';
-        }
-        res += 'if (data.'+_name+' == undefined)\n'
-        res += '  throw new Error("Error: '+_name+' doesn\'t exist")\n'
+          }
+		    }
+		    else if (_type == 'array') {
+		      _name = '';
+		      var _tab = false;
+		      for (k = 1 ; _parentsArray[k] ; k++) {
+			      if (_parentsArray[k] == _which)
+			        _tab = true;
+		        _name += _parentsArray[k];
+			      if (_tab == true)
+		          _name += '[0]'
+		        if (_parentsArray[k + 1])
+			        _name += '.';
+		        _tab = false;
+		      }
+		    }
+		    res += 'if (data.'+_name+' == undefined)\n'//&& options.throwErrorOnUndefined == true)\n'
+        res += '  throw new Error("Error: '+_name+' is undefined")\n'
+        // res += 'else if (data.'+_name+' == undefined && options.throwErrorOnUndefined == false)\n'
+        // res += '  debug("Warning: '+_name+' is undefined")\n'
       }
     }
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,7 +1,6 @@
 var extracter = require('./extracter');
 var parser = require('./parser');
 var helper = require('./helper');
-// var util = require('util')
 
 var builder = {
 
@@ -40,7 +39,6 @@ var builder = {
               var _descriptor = extracter.splitXml(xmlWithoutMarkers, _dynamicDescriptor);
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
-              // console.log(util.inspect(_descriptor, false, null));
               var _builder = builder.getBuilderFunction(_descriptor, options.formatters);
               var _obj = {
                 d : data,
@@ -302,7 +300,7 @@ var builder = {
    * @param {object} descriptor : data descriptor computed by the analyzer
    * @return {function} f
    */
-  getBuilderFunction : function (descriptor, existingFormatters) {
+  getBuilderFunction : function (descriptor, existingFormatters, options) {
     var that = this;
     // declare an object which will contain all the code (by section) of the generated function
     var _code = {
@@ -645,42 +643,50 @@ function removeFrom (arr, value) {
    * @param {object} descriptor : data descriptor computed by the analyzer
    * @return {string} s
    */
-function genErrorGest (description, option) {
+function genErrorGest (description) {
   var res = '';
+  res += 'if (Object.keys(options).length === 0 && options.constructor === Object)\n';
+  res += '  options.throwErrorOnUndefined = false;\n';
+  res += 'if (options == undefined)\n';
+  res += '  options = { throwErrorOnUndefined : false };\n';
+  res += 'if (options.throwErrorOnUndefined == undefined)\n';
+  res += '  options.throwErrorOnUndefined = false;\n';
   for (var i = 0 ; description.hierarchy[i] ; i++) {
     if (description.dynamicData[description.hierarchy[i]].xmlParts.length != 0) {
       for (var j = 0 ; description.dynamicData[description.hierarchy[i]].xmlParts[j] ; j++) {
-        var _parentsArray = []
-        for (var k = 0 ; description.dynamicData[description.hierarchy[i]].parents[k] ; k++) {
-          var _tmpParent = 
-          { 
-            name : description.dynamicData[description.hierarchy[i]].parents[k],
-            type : description.dynamicData[description.hierarchy[i]].parents[k]
+	if (description.dynamicData[description.hierarchy[i]].parents) {
+	  var _parentsArray = []
+          for (var k = 0 ; description.dynamicData[description.hierarchy[i]].parents[k] ; k++) {
+            var _tmpParent =
+		{
+		  name : description.dynamicData[description.hierarchy[i]].parents[k],
+		  type : description.dynamicData[description.hierarchy[i]].parents[k]
+		}
+            _tmpParent.name = description.dynamicData[_tmpParent.name].name
+            _tmpParent.type = description.dynamicData[_tmpParent.type].type
+            _parentsArray.push(_tmpParent);
           }
-          _tmpParent.name = description.dynamicData[_tmpParent.name].name
-          _tmpParent.type = description.dynamicData[_tmpParent.type].type
-          _parentsArray.push(_tmpParent);
-        }
-        var _parent = description.dynamicData[description.hierarchy[i]].xmlParts[j].obj;
-        var _parentType = description.dynamicData[_parent].type;
-        var _parent = description.dynamicData[_parent].name;
-        var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr
-        _parentsArray.push({name : _parent, type : _parentType});
-        _parentsArray.push({name : _name, type : "string"});
-        var _path = ''
-        for (var l = 1 ; _parentsArray[l] ; l++) {
-          res += 'if (data.'+_path+_parentsArray[l].name+' === undefined && options.throwErrorOnUndefined == true)\n'
-          res += '  throw new Error("Error: '+_path+_parentsArray[l].name+' is undefined")\n'
-          if (_parentsArray[l].type == 'array') {
-            res += 'if (Array.isArray(data.'+_path+_parentsArray[l].name+') === false)\n';
-            res += '  throw new Error("Error: '+_path+_parentsArray[l].name+' is not array")\n';
+          var _parent = description.dynamicData[description.hierarchy[i]].xmlParts[j].obj;
+          var _parentType = description.dynamicData[_parent].type;
+          var _parent = description.dynamicData[_parent].name;
+          var _name = description.dynamicData[description.hierarchy[i]].xmlParts[j].attr
+          _parentsArray.push({name : _parent, type : _parentType});
+          _parentsArray.push({name : _name, type : "string"});
+          var _path = ''
+          for (var l = 1 ; _parentsArray[l] ; l++) {
+            res += 'if (options.throwErrorOnUndefined == true && data.'+_path+_parentsArray[l].name+' === undefined)\n';
+            res += '  throw new Error("Error: '+_path+_parentsArray[l].name+' is undefined")\n';
+            if (_parentsArray[l].type == 'array') {
+              res += 'if (options.throwErrorOnUndefined == true && Array.isArray(data.'+_path+_parentsArray[l].name+') === false)\n';
+              res += '  throw new Error("Error: '+_path+_parentsArray[l].name+' is not array")\n';
+            }
+            _path += _parentsArray[l].name
+            if (_parentsArray[l].type === 'array')
+              _path += '[0]'
+            if (_parentsArray[l + 1])
+              _path += '.'
           }
-          _path += _parentsArray[l].name
-          if (_parentsArray[l].type === 'array')
-            _path += '[0]'
-          if (_parentsArray[l + 1])
-            _path += '.'
-        }
+	}
       }
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ var carbone = {
         params[attr] = options[attr];
       }
       else {
-        throw Error('Undefined options :' + attr);
+        throw Error('Undefined options : ' + attr);
       }
     }
     if (options.templatePath !== undefined) {
@@ -149,6 +149,10 @@ var carbone = {
    * @param {Function}     callbackRaw(err, res, reportName) : Function called after generation with the result
    */
   render : function (templatePath, data, optionsRaw, callbackRaw) {
+    for (var attr in optionsRaw) {
+      if (params[attr] === undefined)
+	return callbackRaw('Undefined options : ' + attr, null)
+    }
     parseOptions(optionsRaw, callbackRaw, function (options, callback) {
       // open the template (unzip if necessary)
       file.openTemplate(templatePath, function (err, template) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,15 +62,16 @@ var carbone = {
     var _nodeVersion = process.versions.node.split('.');
     var _tmpDir = (parseInt(_nodeVersion[0], 10) === 0 && parseInt(_nodeVersion[1], 10) < 10) ? os.tmpDir() : os.tmpdir();
 
-    params.tempPath         = _tmpDir;
-    params.templatePath     = process.cwd();
-    params.factories        = 1;
-    params.attempts         = 2;
-    params.startFactory     = false;
-    params.uidPrefix        = 'c';
-    params.pipeNamePrefix   = '_carbone';
-    params.lang             = 'en';
-    params.translations     = {};
+    params.tempPath                         = _tmpDir;
+    params.templatePath                     = process.cwd();
+    params.factories                        = 1;
+    params.attempts                         = 2;
+    params.startFactory                     = false;
+    params.uidPrefix                        = 'c';
+    params.pipeNamePrefix                   = '_carbone';
+    params.lang                             = 'en';
+    params.translations                     = {};
+    params.throwErrorOnUndefined            = false;
   },
 
   /**
@@ -226,14 +227,15 @@ function parseOptions (options, callbackFn, callback) {
   // analyze pre-declared variables in the Object "options"
   parser.findVariables(options.variableStr, function (err, str, variables) {
     var _options = {
-      enum              : options.enum,
-      lang              : options.lang || params.lang,
-      translations      : options.translations || params.translations,
-      complement        : options.complement,
-      reportName        : options.reportName,
-      convertTo         : options.convertTo,
-      formatters        : carbone.formatters,
-      existingVariables : variables
+      enum                  : options.enum,
+      lang                  : options.lang || params.lang,
+      translations          : options.translations || params.translations,
+      complement            : options.complement,
+      reportName            : options.reportName,
+      convertTo             : options.convertTo,
+      formatters            : carbone.formatters,
+      existingVariables     : variables,
+      throwErrorOnUndefined : options.throwErrorOnUndefined
     };
     return callback(_options, callbackFn);
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,10 +149,6 @@ var carbone = {
    * @param {Function}     callbackRaw(err, res, reportName) : Function called after generation with the result
    */
   render : function (templatePath, data, optionsRaw, callbackRaw) {
-    for (var attr in optionsRaw) {
-      if (params[attr] === undefined)
-	return callbackRaw('Undefined options : ' + attr, null)
-    }
     parseOptions(optionsRaw, callbackRaw, function (options, callback) {
       // open the template (unzip if necessary)
       file.openTemplate(templatePath, function (err, template) {

--- a/lib/params.js
+++ b/lib/params.js
@@ -6,25 +6,27 @@ var tmpDir = (parseInt(nodeVersion[0], 10) === 0 && parseInt(nodeVersion[1], 10)
 
 module.exports  = {
   /* Temp directory */
-  tempPath        : tmpDir,
+  tempPath                 : tmpDir,
   /* Template path */
-  templatePath    : process.cwd(),
+  templatePath             : process.cwd(),
   /* Number of LibreOffice + Python factory to start by default. One factory = 2 threads */
-  factories       : 1,
+  factories                : 1,
   /* If LibreOffice fails to convert one document, how many times we re-try to convert this file? */
-  attempts        : 3,
+  attempts                 : 3,
   /* If true, it will start LibreOffice + Python factory immediately (true by default if the carbone server is used). 
      If false, it will start LibreOffice + Python factory only when at least one document conversion is needed.*/
-  startFactory    : false,
+  startFactory             : false,
   /* The method helper.getUID() add this prefix in the uid */
-  uidPrefix       : 'c',
+  uidPrefix                : 'c',
   /* If multiple factories are used, the pipe name is generated automatically to avoid conflicts */
-  pipeNamePrefix  : '_carbone',
+  pipeNamePrefix           : '_carbone',
   /* list of file parsed for translation and find tools */
-  extensionParsed : '(odt|ods|odp|xlsx|docx|pptx|xml|html)',
+  extensionParsed          : '(odt|ods|odp|xlsx|docx|pptx|xml|html)',
   /* lang of carbone and moment.js */
-  lang            : 'en',
+  lang                     : 'en',
   /* all locales are loaded in memory */
-  translations    : {}
+  translations             : {},
+  /* If true, throw Error on undefined data */
+  throwErrorOnUndefined    : false
 };
 

--- a/test/test.builder.buildXML.js
+++ b/test/test.builder.buildXML.js
@@ -31,7 +31,7 @@ describe('builder.buildXML', function () {
     }
     var _options = { throwErrorOnUndefined : true };
     builder.buildXML(_xml, _data, _options, function (err, _xmlBuilt) {
-      helper.assert(err.message, "Error: d.movie[0].type is undefined");
+      helper.assert(err.message, "Error: d.movie[].type is undefined");
       helper.assert(_xmlBuilt, null);
       done();
     });

--- a/test/test.builder.buildXML.js
+++ b/test/test.builder.buildXML.js
@@ -2,13 +2,14 @@ var assert = require('assert');
 var builder = require('../lib/builder');
 var helper = require('../lib/helper');
 
-describe('builder.buildXML', function () {
+describe.only('builder.buildXML', function () {
 
   it('should return an error if one attribute of data is undefined', function (done) {
     var _xml = '<xml> {d.firstname} is a {d.type.name} </xml>';
-    var _data = {};
-    builder.buildXML(_xml, _data, function (err, _xmlBuilt) {
-      helper.assert(err.message, 'Error: d.firstname doesn\'t exist');
+    var _data = { foo : "bar" };
+    var _options = { throwErrorOnUndefined : true };
+    builder.buildXML(_xml, _data, _options, function (err, _xmlBuilt) {
+      helper.assert(err.message, 'Error: d.firstname is undefined');
       helper.assert(_xmlBuilt, null);
       done();
     });

--- a/test/test.builder.buildXML.js
+++ b/test/test.builder.buildXML.js
@@ -4,6 +4,15 @@ var helper = require('../lib/helper');
 
 describe('builder.buildXML', function () {
 
+  it('should return an error if one attribute of data is undefined', function (done) {
+    var _xml = '<xml> {d.firstname} is a {d.type.name} </xml>';
+    var _data = {};
+    builder.buildXML(_xml, _data, function (err, _xmlBuilt) {
+      helper.assert(err.message, 'Error: d.firstname doesn\'t exist');
+      helper.assert(_xmlBuilt, null);
+      done();
+    });
+  });
   it.skip('should work if the same array is repeated two times in the xml <tr>d[i].product</tr>    <tr>d[i].product</tr>');
   it.skip('should escape special characters > < & " \' even if a formatter is used (output of a formatter)');
   it('should return the xml if no data is passed', function (done) {

--- a/test/test.builder.buildXML.js
+++ b/test/test.builder.buildXML.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var builder = require('../lib/builder');
 var helper = require('../lib/helper');
 
-describe.only('builder.buildXML', function () {
+describe('builder.buildXML', function () {
 
   it('should return an error if one attribute of data is undefined', function (done) {
     var _xml = '<xml> {d.firstname} is a {d.type.name} </xml>';
@@ -14,6 +14,50 @@ describe.only('builder.buildXML', function () {
       done();
     });
   });
+  it('should throw an Error cause of an array in the data', function (done) {
+    var _xml = '<xml> {d.movie[0].type} is the favorite genre of movie of {d.name.first} {d.name.last} </xml>';
+    var _data =
+    {
+      name :
+      {
+        first : "Léo",
+        last : "Labruyère"
+      },
+      movie :
+      [
+        { name : "Matrix" },
+        { name : "Avengers" }
+      ]
+    }
+    var _options = { throwErrorOnUndefined : true };
+    builder.buildXML(_xml, _data, _options, function (err, _xmlBuilt) {
+      helper.assert(err.message, "Error: d.movie[0].type is undefined");
+      helper.assert(_xmlBuilt, null);
+      done();
+    });
+  })
+  it('should replace all the tag by the data (throwErrorOnUndefined enabled)', function (done) {
+    var _xml = '<xml> {d.movie[0].name} is the favorite movie of {d.name.first} {d.name.last} </xml>';
+    var _data =
+    {
+      name :
+      {
+        first : "Léo",
+        last : "Labruyère"
+      },
+      movie :
+      [
+        { name : "Matrix" },
+        { name : "Avengers" }
+      ]
+    }
+    var _options = { throwErrorOnUndefined : true };
+    builder.buildXML(_xml, _data, _options, function (err, _xmlBuilt) {
+      helper.assert(err, null);
+      helper.assert(_xmlBuilt, "<xml> Matrix is the favorite movie of Léo Labruyère </xml>");
+      done();
+    });
+  })
   it.skip('should work if the same array is repeated two times in the xml <tr>d[i].product</tr>    <tr>d[i].product</tr>');
   it.skip('should escape special characters > < & " \' even if a formatter is used (output of a formatter)');
   it('should return the xml if no data is passed', function (done) {


### PR DESCRIPTION
Added an option (throwErrorOnUndefined);
Added data check;

When throwErrorOnUndefined = true, carbone will throw error on unvalid or undefine data.
Example :
data = { } and xml = <xml> {d.name} <\xml>
will throw "Error: data.name is undefined"