### PR TITLE
Windows PDF support

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -421,6 +421,9 @@ function sendToFactory (factory, job) {
  */
 function detectLibreOffice (additionalPaths) {
   function _findBundledPython(sofficePath, pythonName) {
+    if (!sofficePath) {
+      return null;
+    }
     // Try finding a Python binary shipped alongside the soffice binary,
     //  either in its actual directory, or - if it's a symbolic link -
     //  in the directory it points to.

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -452,7 +452,7 @@ function detectLibreOffice () {
       'C:\\Program Files\\LibreOffice 5',
       'C:\\Program Files (x86)\\LibreOffice 5'
     ];
-    for (var i = 0; i < pathsToCheck && !programRoot; i += 1) {
+    for (var i = 0; i < pathsToCheck.length && !programRoot; i += 1) {
       if (fs.existsSync(path.join(pathsToCheck[i], 'program', 'python.exe'))) {
         converterOptions.pythonExecPath = path.join(pathsToCheck[i], 'program', 'python.exe');
         converterOptions.sofficeExecPath = path.join(pathsToCheck[i], 'program', 'soffice.exe');

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -4,6 +4,7 @@ var helper = require('./helper');
 var spawn = require('child_process').spawn;
 var params = require('./params');
 var debug = require('debug')('carbone:converter');
+var convertToURL = require('./lopath').convertToURL;
 
 var pythonFile = path.join(__dirname, 'converter.py');
 
@@ -193,12 +194,15 @@ function addConversionFactory (callback) {
     // re-use previous directory if possible (faster restart)
     _userCachePath = _prevFactory.userCachePath;
   }
+  // generate a URL in LibreOffice's format so that it's portable across OSes:
+  // see: https://wiki.openoffice.org/wiki/URL_Basics
+  var _userCacheURL = convertToURL(_userCachePath);
 
   // generate a unique pipe name
   var _pipeName = params.pipeNamePrefix + '_' +_uniqueName;
   var _connectionString = 'pipe,name=' + _pipeName + ';urp;StarOffice.ComponentContext';
   var _officeParams = ['--headless', '--invisible', '--nocrashreport', '--nodefault', '--nologo', '--nofirststartwizard', '--norestore',
-    '--quickstart', '--nolockcheck', '--accept='+_connectionString, '-env:UserInstallation=file://'+_userCachePath ];
+    '--quickstart', '--nolockcheck', '--accept='+_connectionString, '-env:UserInstallation='+_userCacheURL ];
 
   // save unique name
   activeFactories.push(_pipeName);

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -470,12 +470,12 @@ function detectLibreOffice (additionalPaths) {
     };
   }
 
-  function _listProgramDirectories(path, pattern) {
+  function _listProgramDirectories(basePath, pattern) {
     try {
-      return fs.readdirSync(path).filter(function _isLibreOfficeDirectory(dirname) {
+      return fs.readdirSync(basePath).filter(function _isLibreOfficeDirectory(dirname) {
         return pattern.test(dirname);
       }).map(function _buildFullProgramPath(dirname) {
-        return path.join(path, dirname, 'program');
+        return path.join(basePath, dirname, 'program');
       });
     } catch (errorToIgnore) {
       return [];

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -5,6 +5,7 @@ var spawn = require('child_process').spawn;
 var params = require('./params');
 var debug = require('debug')('carbone:converter');
 var convertToURL = require('./lopath').convertToURL;
+var which = require('which');
 
 var pythonFile = path.join(__dirname, 'converter.py');
 
@@ -418,55 +419,103 @@ function sendToFactory (factory, job) {
 /**
  * Detect If LibreOffice and python are available at startup
  */
-function detectLibreOffice () {
+function detectLibreOffice (additionalPaths) {
+  function _findBundledPython(sofficePath, pythonName) {
+    // Try finding a Python binary shipped alongside the soffice binary,
+    //  either in its actual directory, or - if it's a symbolic link -
+    //  in the directory it points to.
+    var symlinkDestination;
+    try {
+      symlinkDestination = path.resolve(path.dirname(sofficePath), fs.readlinkSync(sofficePath));
+      // Assume symbolic link, will throw in case it's not:
+      sofficeActualDirectory = path.dirname(symlinkDestination);
+    } catch (errorToIgnore) {
+      // Not a symlink.
+      sofficeActualDirectory = path.dirname(sofficePath);
+    }
+    // Check for the Python binary in the actual soffice path:
+    try {
+      return which.sync(pythonName, { path: sofficeActualDirectory });
+    } catch (errorToIgnore) {
+      // No bundled Python found.
+      return null;
+    }
+  }
+
+  function _findBinaries(paths, pythonName, sofficeName) {
+    var whichPython;
+    var whichSoffice;
+    var sofficeActualDirectory;
+    // Look for the soffice binary - first in the well-known paths, then in
+    //  the system PATH. On Linux, this prioritizes "upstream" (TDF) packages
+    //  over distro-provided ones from the OS' repository.
+    whichSoffice = which.sync(sofficeName, { path: paths.join(':'), nothrow: true }) || which.sync(sofficeName, { nothrow: true }) || null;
+    // Check for a Python binary bundled with soffice, fall back to system-wide:
+    // This is a bit more complex, since we deal with some corner cases.
+    // 1. Hopefully use the python from the original soffice package, same dir
+    //  (this might fail on Mac if python is not in MacOS/, but in Resources/).
+    // 1a. Corner case: on Linux, if soffice was in /usr/bin/soffice and NOT
+    //  a symlink, then we would hit /usr/bin/python, which is probably python2.
+    //  This is why we try with python3 first, to defend against this.
+    // 2. Try finding it in any of the well-known paths - this might result in
+    //  using Python from *another install* of LibreOffice, but it should be ok.
+    // 3. Fall back to system python (hopefully named python3).
+    whichPython = _findBundledPython(whichSoffice, 'python3') || _findBundledPython(whichSoffice, 'python') || which.sync('python', { path: paths.join(':'), nothrow: true }) || which.sync('python3', { nothrow: true }) || which.sync('python', { nothrow: true }) || null;
+    return {
+      soffice: whichSoffice,
+      python: whichPython
+    };
+  }
+
+  function _listProgramDirectories(path, pattern) {
+    try {
+      return fs.readdirSync(path).filter(function _isLibreOfficeDirectory(dirname) {
+        return pattern.test(dirname);
+      }).map(function _buildFullProgramPath(dirname) {
+        return path.join(path, dirname, 'program');
+      });
+    } catch (errorToIgnore) {
+      return [];
+    }
+  }
+
+  var pathsToCheck = additionalPaths || [];
+  // overridable file names to look for in the checked paths:
+  var pythonName = 'python';
+  var sofficeName = 'soffice';
+  var linuxDirnamePattern = /^libreoffice\d+\.\d+$/;
+  var windowsDirnamePattern = /^LibreOffice \d+(?:\.\d+)?$/i;
 
   if (process.platform === 'darwin') {
-    // it is better to use the python bundled with LibreOffice
-    var _path = 'MacOS';
-    if (fs.existsSync('/Applications/LibreOffice.app/Contents/' + _path + '/python') === false) {
-      _path = 'Resources';
-    }
-
-    if (fs.existsSync('/Applications/LibreOffice.app/Contents/' + _path + '/python') === true) {
-      isLibreOfficeFound = true;
-      converterOptions.pythonExecPath = '/Applications/LibreOffice.app/Contents/' + _path + '/python';
-      converterOptions.sofficeExecPath = '/Applications/LibreOffice.app/Contents/MacOS/soffice';
-    }
+    pathsToCheck = pathsToCheck.concat([
+      // It is better to use the python bundled with LibreOffice:
+      '/Applications/LibreOffice.app/Contents/MacOS',
+      '/Applications/LibreOffice.app/Contents/Resources'
+    ]);
   }
   else if (process.platform === 'linux') {
-    var directories = fs.readdirSync('/opt');
-    var patternLibreOffice = /libreoffice\d+\.\d+/;
-    for (var i = 0; i < directories.length; i++) {
-      if (patternLibreOffice.test(directories[i]) === true) {
-        var directoryLibreOffice = '/opt/' + directories[i] + '/program';
-        if (fs.existsSync(directoryLibreOffice + '/python') === true) {
-          converterOptions.pythonExecPath = directoryLibreOffice + '/python';
-          converterOptions.sofficeExecPath = directoryLibreOffice + '/soffice';
-          isLibreOfficeFound = true;
-        }
-      }
-    }
+    // The Document Foundation packages (.debs, at least) install to /opt,
+    //  into a directory named after the contained LibreOffice version.
+    // Add any existing directories that match this to the list.
+    pathsToCheck = pathsToCheck.concat(_listProgramDirectories('/opt', linuxDirnamePattern));
   }
   else if (process.platform === 'win32') {
-    // Find the directory that LibreOffice is installed in:
-    // (This code currently only supports LibreOffice 5)
-    //TODO: Add support for configurable, separate install paths for python and soffice.
-    var programRoot;
-    var pathsToCheck = [
-      'C:\\Program Files\\LibreOffice 5',
-      'C:\\Program Files (x86)\\LibreOffice 5'
-    ];
-    for (var i = 0; i < pathsToCheck.length && !programRoot; i += 1) {
-      if (fs.existsSync(path.join(pathsToCheck[i], 'program', 'python.exe'))) {
-        converterOptions.pythonExecPath = path.join(pathsToCheck[i], 'program', 'python.exe');
-        converterOptions.sofficeExecPath = path.join(pathsToCheck[i], 'program', 'soffice.exe');
-        isLibreOfficeFound = true;
-      }
-    }
-
+    pathsToCheck = pathsToCheck
+                   .concat(_listProgramDirectories('C:\\Program Files', windowsDirnamePattern))
+                   .concat(_listProgramDirectories('C:\\Program Files (x86)', windowsDirnamePattern));
+    pythonName = 'python.exe';
   }
   else {
-    debug('your platform is not supported yet');
+    debug('your platform "%s" is not supported yet', process.platform);
+  }
+
+  // Common logic for all OSes: perform the search and save results as options:
+  var foundPaths = _findBinaries(pathsToCheck, pythonName, sofficeName);
+  if (foundPaths.soffice) {
+    debug('LibreOffice found: soffice at %s, python at %s', foundPaths.soffice, foundPaths.python);
+    isLibreOfficeFound = true;
+    converterOptions.pythonExecPath = foundPaths.python;
+    converterOptions.sofficeExecPath = foundPaths.soffice;
   }
 
   if (isLibreOfficeFound === false) {
@@ -482,3 +531,4 @@ process.on('exit', function () {
 });
 
 module.exports = converter;
+module.exports.detectLibreOffice = detectLibreOffice;

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -462,8 +462,15 @@ function detectLibreOffice (additionalPaths) {
     //  This is why we try with python3 first, to defend against this.
     // 2. Try finding it in any of the well-known paths - this might result in
     //  using Python from *another install* of LibreOffice, but it should be ok.
+    //  This is only attempted if the paths exist on this system to avoid
+    //  a fallback to system PATH that "which" does when passed an empty string.
     // 3. Fall back to system python (hopefully named python3).
-    whichPython = _findBundledPython(whichSoffice, 'python3') || _findBundledPython(whichSoffice, 'python') || which.sync('python', { path: paths.join(':'), nothrow: true }) || which.sync('python3', { nothrow: true }) || which.sync('python', { nothrow: true }) || null;
+    whichPython = _findBundledPython(whichSoffice, 'python3') ||
+                  _findBundledPython(whichSoffice, 'python') ||
+                  (paths.length > 0 && which.sync('python3', { path: paths.join(':'), nothrow: true })) ||
+                  (paths.length > 0 && which.sync('python', { path: paths.join(':'), nothrow: true })) ||
+                  which.sync('python3', { nothrow: true }) ||
+                  which.sync('python', { nothrow: true }) || null;
     return {
       soffice: whichSoffice,
       python: whichPython

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -443,6 +443,24 @@ function detectLibreOffice () {
       }
     }
   }
+  else if (process.platform === 'win32') {
+    // Find the directory that LibreOffice is installed in:
+    // (This code currently only supports LibreOffice 5)
+    //TODO: Add support for configurable, separate install paths for python and soffice.
+    var programRoot;
+    var pathsToCheck = [
+      'C:\\Program Files\\LibreOffice 5',
+      'C:\\Program Files (x86)\\LibreOffice 5'
+    ];
+    for (var i = 0; i < pathsToCheck && !programRoot; i += 1) {
+      if (fs.existsSync(path.join(pathsToCheck[i], 'program', 'python.exe'))) {
+        converterOptions.pythonExecPath = path.join(pathsToCheck[i], 'program', 'python.exe');
+        converterOptions.sofficeExecPath = path.join(pathsToCheck[i], 'program', 'soffice.exe');
+        isLibreOfficeFound = true;
+      }
+    }
+
+  }
   else {
     debug('your platform is not supported yet');
   }

--- a/lib/lopath.js
+++ b/lib/lopath.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var path = require('path');
+var url = require('url');
+
+// ### Error definitions ###
+
+function PathError(message) {
+	this.name = 'PathError';
+	this.code = 'PathError';
+	this.message = message || 'Failed to convert path';
+	if (typeof Error.captureStackTrace === 'function') {
+		Error.captureStackTrace(this, PathError);
+	}
+}
+PathError.prototype = new Error();
+module.exports.PathError = PathError;
+
+// ### Utility functions ###
+
+/**
+ * Convert an absolute path to an absolute URL understood by LibreOffice and
+ *  OpenOffice. This is necessary because LO/OO use a cross-platform path format
+ *  that does not match paths understood natively by OSes.
+ * If the input is already a URL, it is returned as-is.
+ * @param {string} inputPath - An absolute path to convert to a URL.
+ * @returns {string} A string suitable for use with LibreOffice as an absolute file path URL.
+ */
+function convertToURL(inputPath) {
+	// Guard clause: if it already looks like a URL, keep it that way.
+	if (inputPath.slice(0, 8) === 'file:///') {
+		return inputPath;
+	}
+	if (!path.isAbsolute(inputPath)) {
+		throw new PathError('Paths to convert must be absolute');
+	}
+	// Split into parts so that we can join into a URL:
+	var normalizedPath = path.normalize(inputPath);
+	// (Use both delimiters blindly - we're aiming for maximum compatibility)
+	var pathComponents = normalizedPath.split(/[\\/]/);
+	// Make sure there is no leading empty element, since we always add a
+	//  leading "/" anyway.
+	if (pathComponents[0] === '') {
+		pathComponents.shift();
+	}
+	var outputURL = 'file:///' + pathComponents.join('/');
+	return outputURL;
+}
+
+module.exports.convertToURL = convertToURL;
+// Alias for OpenOffice/LibreOffice script language compatibility:
+module.exports.ConvertToURL = convertToURL;
+
+//TODO: Add a function for converting URLs to paths.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "moment": "=2.18.1",
     "moxie-zip": "=0.0.3",
     "timsort": "=0.3.0",
+    "which": "^1.3.1",
     "yauzl": "=2.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This changeset adds basic support for rendering PDFs using LibreOffice on the Windows operating system and fixes LibreOffice install path detection on all supported OSes.

## Manual functional tests performed:
* LibreOffice 5.3.2.2 (x64) on Windows Server 2016 Standard
* LibreOffice 5.2.7.2 on Debian 9.4, amd64, installed from Debian repository
* LibreOffice 5.3.2.2 on Debian 9.4, amd64, from The Document Foundation upstream repo (using method from carbone's README.md)

(All tests performed using the shipped unit tests + output PDF inspection, as well as our in-house tool for rendering PDFs that uses Carbone; the latter is not public.)

## Features:
* Cross-platform URL/path passing to the LibreOffice process
* Improved path detection for `soffice` and `python` across all operating platforms (including Linux `/opt` vs. `/usr/bin` etc.) with optional configuration by re-running `detectLibreOffice(additionalPaths : string[])`

## Known issues:
* Unit tests are in a poor shape: on Linux, some are already failing out-of-the-box; on Windows, most process-management tests are non-functional, supposedly due to kill/spawn semantics and filesystem locking that prevents file removal.

## Usage changes
* On Windows and GNU/Linux, the converter module now detects installs of LibreOffice outside of the previously hard-coded `/opt` path - now, it is enough to install an `soffice` binary in $PATH for it to be detected (most distros do this). The old paths still have priority to avoid breaking existing software.
* It is now possible to use a Python install independent from the LibreOffice package. This is advantageous because major distros such as Debian ship LibreOffice without a bundled Python.
* Using `DEBUG=debug:converter`, it is possible to inspect the auto-detected paths to binaries.