### PR TITLE
Dynamic variables in key names

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -358,6 +358,7 @@ var builder = {
   getBuilderFunction : function (descriptor, existingFormatters, variables) {
     var that = this;
     var variableNamesToPaths = {};
+    variables = variables || {};
     for (var i = 0; i < variables.length; i += 1) {
       variableNamesToPaths[variables[i].name] = variables[i].code;
     }
@@ -665,9 +666,10 @@ module.exports = builder;
  * @param {object.<string,string>} variableMap - A map that has known variable names as keys and
  */
 function resolveKeyToExpression(objectName, variableMap) {
-  // Guard clause: empty inputs, nulls etc. yield an empty string.
-  if (!objectName) {
-    return "''";
+  // Keep non-string values as they are - some logic in the builder function
+  //  relies on checking if name parts/keys are null or falsy.
+  if (typeof objectName !== 'string') {
+    return objectName;
   }
   var matches = objectName.match(/^\$\$([a-zA-Z0-9_]+)$/);
   if (!matches || matches.length < 2) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -452,7 +452,7 @@ var builder = {
       else if (_type === 'objectInArray') {
         var _arrayOfObjectName = _objName+'_array';
         var _arrayOfObjectIndexName = _objName+'_i';
-        _code.add('prev','main', 'var ' + _arrayOfObjectName+'='+'('+_objParentName+' !== undefined)? '+_objParentName+'['+_realObjKey+']:[];\n');
+        _code.add('prev','main', 'var ' + _arrayOfObjectName+'='+'('+_objParentName+')? '+_objParentName+'['+_realObjKey+']:[];\n');
         var _conditionToFindObject = _dynamicData[_objName].conditions || [];
         var _objNameTemp = _objName+'_temp';
 
@@ -523,12 +523,12 @@ var builder = {
             var _iteratorObjName = _objName+'_itObj';
             _code.add('prev', 'main', ' var '+_iteratorName+' = 0;\n'); // TODO return errors if the iterator is not defined
             if (_containSpecialIterator===true) {
-              _code.add('main', 'if('+ _objName +' !== undefined){\n');
+              _code.add('main', 'if('+ _objName +'){\n');
             }
             // the iterator is inside an object
             if (_iterator.obj !== undefined) {
               _code.add('prev','main', ' var '+_iteratorObjName+' = '+_objName+"['"+_iterator.obj+"'];\n");
-              _code.add('prev','main', ' if('+_iteratorObjName+' !== undefined) {\n');
+              _code.add('prev','main', ' if('+_iteratorObjName+') {\n');
               _code.add('prev','main', '   '+_iteratorName+' = '+_iteratorObjName+"['"+_iterator.attr+"'];\n");
               _code.add('prev','main', ' }\n');
             }
@@ -586,7 +586,7 @@ var builder = {
           // handle conditions
           _code.add('main', '_strPart.rowShow = true;\n');
           _code.add('main', that.getFilterString(_conditions, '_strPart.rowShow = false', _objName, true));
-          _code.add('main', 'if('+ _dataObj +' !== undefined){\n');
+          _code.add('main', 'if('+ _dataObj +'){\n');
           _code.add('main', 'var _str = ' + _dataObj + "[" + _dataAttr + "]" + ';\n');
           _code.add('main', '_formatterOptions.stopPropagation = false;\n');
           _code.add('main', that.getFormatterString('_str', '_formatterOptions', _formatters, existingFormatters, false));

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -446,7 +446,7 @@ var builder = {
       if (_type === 'object') {
         // declare any nested object
         if (_objName!=='_root') {
-          _code.add('prev','main', _objName+'='+'('+_objParentName+' !== undefined)?'+_objParentName+'['+_realObjKey+']:{};\n');
+          _code.add('prev','main', _objName+'='+'('+_objParentName+')?'+_objParentName+'['+_realObjKey+']:{};\n');
         }
       }
       else if (_type === 'objectInArray') {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -42,7 +42,7 @@ var builder = {
               var _descriptor = extracter.splitXml(xmlWithoutMarkers, _dynamicDescriptor);
               _descriptor = extracter.buildSortedHierarchy(_descriptor);
               _descriptor = extracter.deleteAndMoveNestedParts(_descriptor);
-              var _builder = builder.getBuilderFunction(_descriptor, options.formatters);
+              var _builder = builder.getBuilderFunction(_descriptor, options.formatters, variables);
               var _obj = {
                 d : data,
                 c : options.complement
@@ -351,10 +351,16 @@ var builder = {
    * This array of strings will be sorted and assemble by assembleXmlParts to get final result.
    *
    * @param {object} descriptor : data descriptor computed by the analyzer
+   * @param {object} existingFormatters - a map of defined formatter functions
+   * @param {object[]} variables - an array of variable descriptors to use for dynamic variable substitutions
    * @return {function} f
    */
-  getBuilderFunction : function (descriptor, existingFormatters) {
+  getBuilderFunction : function (descriptor, existingFormatters, variables) {
     var that = this;
+    var variableNamesToPaths = {};
+    for (var i = 0; i < variables.length; i += 1) {
+      variableNamesToPaths[variables[i].name] = variables[i].code;
+    }
     // declare an object which will contain all the code (by section) of the generated function
     var _code = {
       init : '',
@@ -419,7 +425,7 @@ var builder = {
     // For each object, generate the code
     for (var _objIndex = 0; _objIndex < _hierarchy.length; _objIndex++) {
       var _objName = _hierarchy[_objIndex];
-      var _realObjName = _dynamicData[_objName].name;
+      var _realObjKey = resolveKeyToExpression(_dynamicData[_objName].name, variableNamesToPaths);
       var _type = _dynamicData[_objName].type;
       var _objParentName = _dynamicData[_objName].parent;
       var _xmlParts = _dynamicData[_objName].xmlParts;
@@ -439,13 +445,13 @@ var builder = {
       if (_type === 'object') {
         // declare any nested object
         if (_objName!=='_root') {
-          _code.add('prev','main', _objName+'='+'('+_objParentName+' !== undefined)?'+_objParentName+'[\''+_realObjName+'\']:{};\n');
+          _code.add('prev','main', _objName+'='+'('+_objParentName+' !== undefined)?'+_objParentName+'['+_realObjKey+']:{};\n');
         }
       }
       else if (_type === 'objectInArray') {
         var _arrayOfObjectName = _objName+'_array';
         var _arrayOfObjectIndexName = _objName+'_i';
-        _code.add('prev','main', 'var ' + _arrayOfObjectName+'='+'('+_objParentName+' !== undefined)? '+_objParentName+'[\''+_realObjName+'\']:[];\n');
+        _code.add('prev','main', 'var ' + _arrayOfObjectName+'='+'('+_objParentName+' !== undefined)? '+_objParentName+'['+_realObjKey+']:[];\n');
         var _conditionToFindObject = _dynamicData[_objName].conditions || [];
         var _objNameTemp = _objName+'_temp';
 
@@ -471,7 +477,7 @@ var builder = {
 
         // declare any nested object
         if (_objName!=='_root') {
-          _code.add('prev', 'main', 'var '+_arrayName+'='+ _objParentName+"['"+_realObjName+"'];\n");
+          _code.add('prev', 'main', 'var '+_arrayName+'='+ _objParentName+'['+_realObjKey+'];\n');
         }
         else {
           _code.add('prev', 'main', 'var '+_arrayName+'='+ _objName+';\n');
@@ -551,11 +557,10 @@ var builder = {
       for (var i = 0; i < _xmlParts.length; i++) {
         var _xmlPart = _xmlParts[i];
         var _dataObj = _xmlPart.obj;
-        var _dataAttr = _xmlPart.attr;
+        var _dataAttr = resolveKeyToExpression(_xmlPart.attr, variableNamesToPaths);
         var _partDepth = _xmlPart.depth;
         var _formatters = _xmlPart.formatters || [];
         var _conditions = _xmlPart.conditions || [];
-
         // keep highest position for the last xml part
         if (_xmlPart.pos > _keepHighestPosition) {
           _keepHighestPosition = _xmlPart.pos;
@@ -581,7 +586,7 @@ var builder = {
           _code.add('main', '_strPart.rowShow = true;\n');
           _code.add('main', that.getFilterString(_conditions, '_strPart.rowShow = false', _objName, true));
           _code.add('main', 'if('+ _dataObj +' !== undefined){\n');
-          _code.add('main', 'var _str = ' + _dataObj + "['" + _dataAttr + "']" + ';\n');
+          _code.add('main', 'var _str = ' + _dataObj + "[" + _dataAttr + "]" + ';\n');
           _code.add('main', '_formatterOptions.stopPropagation = false;\n');
           _code.add('main', that.getFormatterString('_str', '_formatterOptions', _formatters, existingFormatters, false));
           // replace null or undefined value by an empty string
@@ -653,6 +658,29 @@ var builder = {
 
 module.exports = builder;
 
+/**
+ * Turn a key (a string that's used as an object index) into an expression
+ *  to be evaluated in the generated builder function.
+ * @param {string} objectName - Name used as the index, for example if the reference was "item.name" then this will be "name".
+ * @param {object.<string,string>} variableMap - A map that has known variable names as keys and
+ */
+function resolveKeyToExpression(objectName, variableMap) {
+  // Guard clause: empty inputs, nulls etc. yield an empty string.
+  if (!objectName) {
+    return "''";
+  }
+  var matches = objectName.match(/^\$\$([a-zA-Z0-9_]+)$/);
+  if (!matches || matches.length < 2) {
+    // This is a normal key reference (.key)
+    return '\'' + objectName + '\'';
+  }
+  // This is a dynamic key reference (.$$var) and should be evaluated in the generated function.
+  var variableName = matches[1];
+  if (!variableMap[variableName]) {
+    return '\'$$' + variableName + '\'';
+  }
+  return '(function() { try { return _root.' + variableMap[variableName] + '; } catch (error) { return \'\'; } })()';
+}
 
 /**
  * Test if two arrays are equal
@@ -704,5 +732,3 @@ function removeFrom (arr, value) {
   }
   return arr;
 }
-
-

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -663,7 +663,7 @@ module.exports = builder;
  * Turn a key (a string that's used as an object index) into an expression
  *  to be evaluated in the generated builder function.
  * @param {string} objectName - Name used as the index, for example if the reference was "item.name" then this will be "name".
- * @param {object.<string,string>} variableMap - A map that has known variable names as keys and
+ * @param {object.<string,string>} variableMap - A map that has known variable names as keys and the target expressions as values. For example, { alias1: 'd.value1' } will result in references $$alias1 to be evaluated at run-time as _root.d.value1.
  */
 function resolveKeyToExpression(objectName, variableMap) {
   // Keep non-string values as they are - some logic in the builder function

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -226,7 +226,7 @@ var parser = {
             _code = _code.replace(new RegExp('\\'+_param.name,'g'), '_$'+_param.index+'_');
           }
         }
-        var _regex = new RegExp('\\$'+_variable+'(?:\\(([\\s\\S]+?)\\))?', 'g');
+        var _regex = new RegExp('(?:^|[^\\$])(\\$' + _variable + '(?:\\(([\\s\\S]+?)\\))?)', 'g');
         existingVariables.push({
           name  : _variable,
           code  : _code,
@@ -263,8 +263,8 @@ var parser = {
             var _pattern = _variable.regex.exec(_markerName);
             while (_pattern !== null) {
               var _code =  _variable.code;
-              var _varStr = _pattern[0];
-              var _paramStr = _pattern[1];
+              var _varStr = _pattern[1];
+              var _paramStr = _pattern[2];
               // if there some parameters?
               if (_paramStr !== undefined) {
                 // separate each parameters


### PR DESCRIPTION
This change adds support for resolving key names in objects using variables. For example, if the data passed to `carbone.render` contains:
```js
{
  "language": "de",
  "item": {
    "names": { "en": "Washing machine", de: "Waschmaschine" }
  }
}
```

Then, in the template, we can use a key from `item.names` that depends on the passed `language` by using a Carbone variable (also called "alias" in the Designer documentation) with a new de-referencing syntax:
```
{#lang = d.language}
{d.item.names.$$lang}
```

Under the hood, this key reference translated to an IIFE that evaluates `_root.d.language` or returns an empty string on error (like when some object along the path is null/undefined).

Only references to known variables are replaced with dynamically-computed keys, so this change preserves compatibility for users of key names with `$$` in them (they work as usual) - unless you define a variable of the same name.

Square brackets were considered to give developers more familiarity (would have been similar to `obj[variable]` in JS), but ultimately a "$$" syntax was chosen that requires minimal changes to the parser/renderer logic.

Note that this function only supports plain, parameter-less aliases/variables so far (no array filters), and the variable code (the part after `=`) must be eval-able.

Basic tests for this renderer feature are provided.