### PR TITLE
Correction of _windowsDirnamePattern

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -494,7 +494,7 @@ function detectLibreOffice (additionalPaths) {
   var _pythonName = 'python';
   var _sofficeName = 'soffice';
   var _linuxDirnamePattern = /^libreoffice\d+\.\d+$/;
-  var _windowsDirnamePattern = /^LibreOffice( \d+(?:\.\d+)?)?$/i;
+  var _windowsDirnamePattern = /^LibreOffice( \d+(?:\.\d+)*?)?$/i;
 
   if (process.platform === 'darwin') {
     _pathsToCheck = _pathsToCheck.concat([

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -494,7 +494,7 @@ function detectLibreOffice (additionalPaths) {
   var _pythonName = 'python';
   var _sofficeName = 'soffice';
   var _linuxDirnamePattern = /^libreoffice\d+\.\d+$/;
-  var _windowsDirnamePattern = /^LibreOffice \d+(?:\.\d+)?$/i;
+  var _windowsDirnamePattern = /^LibreOffice( \d+(?:\.\d+)?)?$/i;
 
   if (process.platform === 'darwin') {
     _pathsToCheck = _pathsToCheck.concat([


### PR DESCRIPTION
Fixes #41 

When trying to convert to pdf file, I got an error telling me that LibreOffice is not installed.

Scenario:
OS: Windows 7 SP1 (x64)
LibreOffice Version: 6.2.5.2 (x64)
soffice.exe Path: 'C:/Program Files/LibreOffice/program/soffice.exe'

The current filter cannot find this path: (Line 497 of file "converter.js")
`var _windowsDirnamePattern = /^LibreOffice \d+(?:\.\d+)?$/i;`

I could correct it locally by changing it to:
`var _windowsDirnamePattern = /^LibreOffice( \d+(?:\.\d+)?)?$/i;`