### PR TITLE
Fix line break replacement when the \n character is a literal text

### DIFF
--- a/formatters/string.js
+++ b/formatters/string.js
@@ -166,7 +166,7 @@ function convCRLF (d) {
   if (typeof d === 'string') {
     var _lineBreak = LINEBREAK[this.extension];
     if (_lineBreak) {
-      return d.replace(/\r?\n/g, _lineBreak);
+      return d.replace(/\\n|\r?\n/g, _lineBreak);
     }
   }
   return d;


### PR DESCRIPTION
Fix for issue #73 